### PR TITLE
Fix logging from the recursive file copy function

### DIFF
--- a/lib/cat.js
+++ b/lib/cat.js
@@ -50,7 +50,9 @@ var cat = (function(){
 
       var notModifiedMsg = onlyChanged ? ' (' + notModifiedCount + ' files were not modified)' : '';
 
-	  logger.info('[copycat] copied ' + copiedFiles.length + ' files' + notModifiedMsg);
+      if(verbose){
+        logger.info('[copycat] copied ' + copiedFiles.length + ' files' + notModifiedMsg);
+      }
     },
     copyFileAsync: function(original, copy, stat){
       if (onlyChanged) {


### PR DESCRIPTION
So it does not log for all of the, say, 2327 subdirectories that I am copying, filling my output...

What should probably happen is verbose should be refactored so it is an integer, where 0 is log nothing, 1 logs the recursive directory entries, and 2 logs absolutely every file, this would not be backwards compatible (although perhaps it could be if it was -1 (for log nothing), 0 (for default), and 1 (for log verbosely).  But at the very least this PR prevents entire log filling up.  Perhaps there could be a single final log that just reports how many files and directories it copied and make that '1', with '0' at none, and also a '2' and '3' logging level...